### PR TITLE
Menu icon Update to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <a href="https://store.google.com/US/?utm_source=hp_header&utm_medium=google_ooo&utm_campaign=GS100042&hl=en-US" target="_blank" id="store">Store</a>
   <a href="https://www.google.com/gmail/about/" target="_blank" id="gmail">Gmail</a>
   <a href="https://www.google.com/imghp?hl=en&ogbl" target="_blank" id="images">Images</a>
-  <a href="https://about.google/intl/en/products/" target="_blank" id="menu"><img src="https://cdn.icon-icons.com/icons2/878/PNG/512/big-and-small-dots_icon-icons.com_68589.png" alt="Menu" style="width:18px;height:18px;"></a>
+  <a href="https://about.google/intl/en/products/" target="_blank" id="menu"><img src="https://raw.githubusercontent.com/TWOdunlami/SearchClone/main/big-and-small-dots_icon-icons.com_68589.ico" alt="Menu" style="width:18px;height:18px;"></a>
   <a href="https://accounts.google.com/signin" target="_blank" id="sign-in">Sign in</a>
  </div>
  <style>


### PR DESCRIPTION
quality - direct link from github [ https://raw.githubusercontent.com/TWOdunlami/SearchClone/main/big-and-small-dots_icon-icons.com_68589.ico ] to ensure the image is not broken when google homepage is launched from deployment page.